### PR TITLE
Update open_clip_torch to 2.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG TARGETPLATFORM
 
 RUN set -x && \
     apt-get update && \
+    apt-get install wget -y && \
+    apt-get update && \
     apt-get install ca-certificates curl  gnupg lsof lsb-release jq -y && \
     apt-get install apt-transport-https ca-certificates curl gnupg2 software-properties-common -y && \
     apt-get update && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,8 @@ redis==4.4.2
 # pin specific packages (last working 0.0.19 image)
 # to fix ARM64 build scikit-learn error
 platformdirs==3.5.0
-timm==0.6.13
+safetensors==0.4.1
+timm==0.9.12
 transformers==4.29.0
 
 flatbuffers==23.5.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Pillow==9.3.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.18.0
+open_clip_torch==2.23.0
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0


### PR DESCRIPTION
* **What is the current behavior?**  
open_clip_torch version is 2.18.0 and wget is not installed.

* **What is the new behavior?**
- Install wget.
- Upgrade the following packages:
open_clip_torch==2.23.0
safetensors==0.4.1
timm==0.9.12

* **Have tests been run against this PR?**  

* **Have appropriate comments and documentation been made on this PR?**  


* **Related changes in other repos** (link commit/PR here)


* **Other information**:



