### PR TITLE
Add missing nltk_data env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN mkdir -p /root/nltk_data/tokenizers && \
     unzip /root/nltk_data/tokenizers/punkt.zip -d /root/nltk_data/tokenizers/ && \
     echo Target platform is "$TARGETPLATFORM"
 
+ENV NLTK_DATA=/root/nltk_data
+
 # Install pip dependencies
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
* **What is the current behavior?**  

We're hosting Marqo using Kubernetes and the library isn't found in the container.
If I manually execute it in the container, we can actually see the error:

```
sh-4.4$ python3
Python 3.8.17 (default, Aug 10 2023, 15:47:44) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-20)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import nltk
>>> nltk.data.find("tokenizers/punkt")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/nltk/data.py", line 583, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt

  Searched in:
    - '/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```

You might need to scroll in here to see the bottom of the response.
As you can see, our directory `/root/nltk_data` isn't being searched in.

* **What is the new behavior?**
```
sh-4.4$ python3
Python 3.8.17 (default, Aug 10 2023, 15:47:44) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-20)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import nltk
>>> nltk.data.find("tokenizers/punkt")
FileSystemPathPointer('/root/nltk_data/tokenizers/punkt/PY3')
```

* **Have tests been run against this PR?**  
only manual testing

* **Have appropriate comments and documentation been made on this PR?**  
nope

* **Related changes in other repos** (link commit/PR here)
related to this line of code: https://github.com/marqo-ai/marqo/blob/mainline/src/marqo/s2_inference/processing/text.py#L28-L31

* **Other information**:



