### PR TITLE
fix torchaudio version for amd64 platform

### DIFF
--- a/scripts/install_torch_amd.sh
+++ b/scripts/install_torch_amd.sh
@@ -7,5 +7,5 @@ if ! [[ "$TARGETPLATFORM" ]]; then
 fi
 
 if [[ "$TARGETPLATFORM" != "linux/arm64" ]]; then
-  pip3 install --no-cache-dir torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113 --upgrade
+  pip3 install --no-cache-dir torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113 --upgrade
 fi


### PR DESCRIPTION

* **What is the current behavior?**  
torchaudio version does not match the torch version on linux/amd64 platform

* **What is the new behavior?**
install torchaudio==0.12.1+cu113 to match the torch version

* **Have tests been run against this PR?**  
Yes

* **Have appropriate comments and documentation been made on this PR?**  
N/A

* **Related changes in other repos** (link commit/PR here)
N/A

* **Other information**:



