### PR TITLE
Downgrade open-clip-torch to 2.24.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Pillow==9.3.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.26.1
+open_clip_torch==2.24.0
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0
@@ -38,7 +38,6 @@ typing-extensions==4.5.0
 urllib3==1.26.16
 timm==1.0.8
 transformers==4.41.2
-safetensors==0.4.1
 einops==0.6.1
 soundfile==0.12.1
 python-magic==0.4.27


### PR DESCRIPTION


* **What is the current behavior?**  
- the latest version of open-clip-torch does not work with `open_clip/ViT-SO400M-14-SigLIP-384/webli` model with the tokenizer fix


* **What is the new behavior?**
- downgrade it to the previous version

* **Have tests been run against this PR?**  


* **Have appropriate comments and documentation been made on this PR?**  


* **Related changes in other repos** (link commit/PR here)


* **Other information**:



