### PR TITLE
Set the java version to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
       bash /scripts/install_ffmpeg.sh; \
     elif [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
       bash /scripts/install_ffmpeg_cuda.sh;  \
-      # Fix the java path for the cuda version
-      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el8.x86_64; \
-      export PATH=$JAVA_HOME/bin:$PATH; \
+      # Choose the java version
+      update-alternatives --set java /usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el8.x86_64/bin/java; \
     else \
       echo "Unsupported platform: ${TARGETARCH}" && exit 1; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,10 @@ RUN bash scripts/install_redis.sh && \
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
       bash /scripts/install_ffmpeg.sh; \
     elif [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-      bash /scripts/install_ffmpeg_cuda.sh; \
+      bash /scripts/install_ffmpeg_cuda.sh;  \
+      # Fix the java path for the cuda version
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el8.x86_64; \
+      export PATH=$JAVA_HOME/bin:$PATH; \
     else \
       echo "Unsupported platform: ${TARGETARCH}" && exit 1; \
     fi


### PR DESCRIPTION
* **What is the current behavior?**  
Installing FFmpeg-cuda introduces java-1.8.0-openjdk and makes it default.. Vespa can not start with this java.

* **What is the new behavior?**
We make java 17 the default version and vespa can start.

* **Have tests been run against this PR?**  


* **Have appropriate comments and documentation been made on this PR?**  


* **Related changes in other repos** (link commit/PR here)


* **Other information**:

Manual tests:
```bash
[root@b72882c91c9e /]# java -version
openjdk version "17.0.13" 2024-10-15 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.13.0.11-1) (build 17.0.13+11-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.13.0.11-1) (build 17.0.13+11-LTS, mixed mode, sharing)
[root@b72882c91c9e /]# 
```

