### PR TITLE
Add hf_transfer to our dependencies

### DIFF
--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -495,3 +495,6 @@ zipp==3.20.2
     #   -r requirements.in
     #   importlib-metadata
     #   importlib-resources
+hf-transfer==0.1.8
+    # via
+    #   -r requirements.in

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -6,7 +6,7 @@
 #
 --extra-index-url https://download.pytorch.org/whl/cu113
 
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
 aiohttp==3.10.9
     # via

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -482,3 +482,6 @@ zipp==3.20.2
     #   -r requirements.in
     #   importlib-metadata
     #   importlib-resources
+hf-transfer==0.1.8
+    # via
+    #   -r requirements.in

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -6,7 +6,7 @@
 #
 --extra-index-url https://download.pytorch.org/whl/cu113
 
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
 aiohttp==3.10.9
     # via

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -97,3 +97,4 @@ websockets==13.1
 zipp==3.20.2
 yarl==1.13.1
 portalocker==2.10.1
+hf-transfer==0.1.8


### PR DESCRIPTION
We add hf_transfer to the dependencies to enable `HF_HUB_ENABLE_HF_TRANSFER=1` feature for faster model downloading. 