### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -81,7 +81,7 @@ einops==0.6.1
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.115.6
+fastapi==0.86.0
     # via
     #   -r requirements.in
     #   fastapi-utils
@@ -393,7 +393,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.41.3
+strlette==0.20.4
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -81,7 +81,7 @@ einops==0.6.1
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.86.0
+fastapi==0.115.6
     # via
     #   -r requirements.in
     #   fastapi-utils

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -13,7 +13,7 @@ aiohttp==3.10.9
     #   -r requirements.in
     #   datasets
     #   fsspec
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
 anyio==3.7.1
     # via
@@ -25,7 +25,7 @@ async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   aiohttp
     #   jsonschema
@@ -54,7 +54,7 @@ cffi==1.17.1
     # via soundfile
 charset-normalizer==2.1.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   nltk
     #   uvicorn

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -393,7 +393,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-strlette==0.20.4
+starlette==0.20.4
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -451,7 +451,7 @@ transformers==4.41.2
     #   multilingual-clip
     #   optimum
     #   sentence-transformers
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
     #   -r requirements.in
     #   huggingface-hub

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -393,7 +393,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.40.0
+starlette==0.41.3
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -393,7 +393,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.45.1
+starlette==0.40.0
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -277,7 +277,7 @@ pooch==1.8.2
     # via librosa
 portalocker==2.10.1
     # via iopath
-protobuf==3.20.2
+protobuf==3.20.1
     # via
     #   -r requirements.in
     #   onnx

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -44,7 +44,7 @@ botocore==1.28.4
     #   s3transfer
 cachetools==5.3.1
     # via -r requirements.in
-certifi==2019.11.28
+certifi==2023.7.22
     # via
     #   -r requirements.in
     #   httpcore
@@ -277,7 +277,7 @@ pooch==1.8.2
     # via librosa
 portalocker==2.10.1
     # via iopath
-protobuf==3.20.1
+protobuf==3.20.2
     # via
     #   -r requirements.in
     #   onnx
@@ -330,7 +330,7 @@ pyyaml==6.0.2
     #   yacs
 readerwriterlock==1.0.9
     # via -r requirements.in
-redis==4.4.2
+redis==4.4.4
     # via -r requirements.in
 regex==2024.9.11
     # via
@@ -393,7 +393,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.20.4
+starlette==0.45.1
     # via fastapi
 sympy==1.13.3
     # via
@@ -465,7 +465,7 @@ typing-extensions==4.5.0
     #   torch
     #   torchvision
     #   uvicorn
-urllib3==1.26.16
+urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -78,7 +78,7 @@ einops==0.6.1
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.86.0
+fastapi==0.115.6
     # via
     #   -r requirements.in
     #   fastapi-utils

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -44,7 +44,7 @@ botocore==1.28.4
     #   s3transfer
 cachetools==5.3.1
     # via -r requirements.in
-certifi==2019.11.28
+certifi==2023.7.22
     # via
     #   -r requirements.in
     #   httpcore
@@ -266,7 +266,7 @@ pooch==1.8.2
     # via librosa
 portalocker==2.10.1
     # via iopath
-protobuf==3.20.1
+protobuf==3.20.2
     # via
     #   -r requirements.in
     #   onnx
@@ -318,7 +318,7 @@ pyyaml==6.0.2
     #   yacs
 readerwriterlock==1.0.9
     # via -r requirements.in
-redis==4.4.2
+redis==4.4.4
     # via -r requirements.in
 regex==2024.9.11
     # via
@@ -381,7 +381,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.20.4
+starlette==0.45.1
     # via fastapi
 sympy==1.13.3
     # via
@@ -452,7 +452,7 @@ typing-extensions==4.5.0
     #   torch
     #   torchvision
     #   uvicorn
-urllib3==1.26.16
+urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -78,7 +78,7 @@ einops==0.6.1
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.115.6
+fastapi==0.86.0
     # via
     #   -r requirements.in
     #   fastapi-utils
@@ -381,7 +381,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.41.3
+strlette==0.20.4
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -381,7 +381,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.40.0
+starlette==0.41.3
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -13,7 +13,7 @@ aiohttp==3.10.9
     #   -r requirements.in
     #   datasets
     #   fsspec
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
 anyio==3.7.1
     # via
@@ -25,7 +25,7 @@ async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   aiohttp
     #   jsonschema
@@ -54,7 +54,7 @@ cffi==1.17.1
     # via soundfile
 charset-normalizer==2.1.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   nltk
     #   uvicorn

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -438,7 +438,7 @@ transformers==4.41.2
     #   multilingual-clip
     #   optimum
     #   sentence-transformers
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
     #   -r requirements.in
     #   huggingface-hub

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -381,7 +381,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-starlette==0.45.1
+starlette==0.40.0
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -381,7 +381,7 @@ soxr==0.3.7
     #   librosa
 sqlalchemy==1.4.54
     # via fastapi-utils
-strlette==0.20.4
+starlette==0.20.4
     # via fastapi
 sympy==1.13.3
     # via

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -266,7 +266,7 @@ pooch==1.8.2
     # via librosa
 portalocker==2.10.1
     # via iopath
-protobuf==3.20.2
+protobuf==3.20.1
     # via
     #   -r requirements.in
     #   onnx

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -98,4 +98,4 @@ zipp==3.20.2
 yarl==1.13.1
 portalocker==2.10.1
 hf-transfer==0.1.8
-starlette==0.45.1
+starlette==0.40.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ fastapi==0.86.0
 uvicorn==0.31.0
 fastapi-utils==0.2.1
 jsonschema==4.17.1
-redis==4.4.2
+redis==4.4.4
 more_itertools==10.4.0
 boto3==1.25.4
 botocore==1.28.4
@@ -15,7 +15,7 @@ validators==0.20.0
 sentence-transformers==2.2.2
 open_clip_torch==2.24.0
 clip-marqo==1.0.2
-protobuf==3.20.1
+protobuf==3.20.2
 onnx==1.12.0
 onnxruntime==1.13.1
 pandas==1.5.1
@@ -25,11 +25,11 @@ psutil==5.9.4
 multilingual-clip==1.0.10
 safetensors==0.4.1
 flatbuffers==23.5.9
-certifi==2019.11.28
+certifi==2023.7.22
 idna==2.8
 six==1.14.0
 typing-extensions==4.5.0
-urllib3==1.26.16
+urllib3==1.26.17
 timm==1.0.8
 transformers==4.41.2
 einops==0.6.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -50,6 +50,7 @@ kazoo==2.10.0
 pycurl==7.45.3
 huggingface-hub==0.25.0
 jinja2==3.1.4
+hf-transfer==0.1.8
 
 # AMD Specific packages
 --extra-index-url https://download.pytorch.org/whl/cu113
@@ -97,5 +98,3 @@ websockets==13.1
 zipp==3.20.2
 yarl==1.13.1
 portalocker==2.10.1
-hf-transfer==0.1.8
-starlette==0.40.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,7 +28,7 @@ flatbuffers==23.5.9
 certifi==2023.7.22
 idna==2.8
 six==1.14.0
-typing-extensions==4.5.0
+typing-extensions==4.8.0
 urllib3==1.26.17
 timm==1.0.8
 transformers==4.41.2

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -15,7 +15,7 @@ validators==0.20.0
 sentence-transformers==2.2.2
 open_clip_torch==2.24.0
 clip-marqo==1.0.2
-protobuf==3.20.2
+protobuf==3.20.1
 onnx==1.12.0
 onnxruntime==1.13.1
 pandas==1.5.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,6 @@
 requests==2.28.1
 anyio==3.7.1
-fastapi==0.115.6
+fastapi==0.86.0
 uvicorn==0.31.0
 fastapi-utils==0.2.1
 jsonschema==4.17.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,6 @@
 requests==2.28.1
 anyio==3.7.1
-fastapi==0.86.0
+fastapi==0.115.6
 uvicorn==0.31.0
 fastapi-utils==0.2.1
 jsonschema==4.17.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -98,3 +98,4 @@ zipp==3.20.2
 yarl==1.13.1
 portalocker==2.10.1
 hf-transfer==0.1.8
+starlette==0.45.1


### PR DESCRIPTION
* **What is the current behavior?**  
There are some security issues regarding our dependencies.

* **What is the new behavior?**
We upgrade the dependencies to address the above security issue, specifically:
1. redis: https://github.com/marqo-ai/marqo-base/security/dependabot/9
2. certifi: https://github.com/marqo-ai/marqo-base/security/dependabot/10
3. urllib3: https://github.com/marqo-ai/marqo-base/security/dependabot/11

* **Have tests been run against this PR?**  


* **Have appropriate comments and documentation been made on this PR?**  


* **Related changes in other repos** (link commit/PR here)


* **Other information**:
Performance tests results:
2.14.1: https://github.com/marqo-ai/marqo/actions/runs/12683818365 
updated_version: https://github.com/marqo-ai/marqo/actions/runs/12683812866


