### PR TITLE
Add orjson==3.10.15 to base image and upgrade vespa to 8.472.109-1.el8 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
 # Install Vespa and pin the version. All versions can be found using `dns list vespa`
 # This is installed as a separate docker layer since we need to upgrade vespa regularly
 RUN dnf config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo && \
-    dnf install -y vespa-8.431.32-1.el8
+    dnf install -y vespa-8.472.109-1.el8
 
 ADD scripts/start_vespa.sh /usr/local/bin/start_vespa.sh
 

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -498,3 +498,6 @@ zipp==3.20.2
 hf-transfer==0.1.8
     # via
     #   -r requirements.in
+orjson==3.10.14
+    # via
+    #   -r requirements.in

--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -498,6 +498,6 @@ zipp==3.20.2
 hf-transfer==0.1.8
     # via
     #   -r requirements.in
-orjson==3.10.14
+orjson==3.10.15
     # via
     #   -r requirements.in

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -485,3 +485,6 @@ zipp==3.20.2
 hf-transfer==0.1.8
     # via
     #   -r requirements.in
+orjson==3.10.14
+    # via
+    #   -r requirements.in

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -485,6 +485,6 @@ zipp==3.20.2
 hf-transfer==0.1.8
     # via
     #   -r requirements.in
-orjson==3.10.14
+orjson==3.10.15
     # via
     #   -r requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,7 +51,7 @@ pycurl==7.45.3
 huggingface-hub==0.25.0
 jinja2==3.1.4
 hf-transfer==0.1.8
-orjson==3.10.14
+orjson==3.10.15
 
 # AMD Specific packages
 --extra-index-url https://download.pytorch.org/whl/cu113

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -99,3 +99,6 @@ websockets==13.1
 zipp==3.20.2
 yarl==1.13.1
 portalocker==2.10.1
+attrs==24.3.0
+pytz==2024.2
+filelock==3.16.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,6 +51,7 @@ pycurl==7.45.3
 huggingface-hub==0.25.0
 jinja2==3.1.4
 hf-transfer==0.1.8
+orjson==3.10.14
 
 # AMD Specific packages
 --extra-index-url https://download.pytorch.org/whl/cu113


### PR DESCRIPTION
* **What is the current behavior?**  


* **What is the new behavior?**
  - Add orjson==3.10.15 to base image
  - upgrade vespa to 8.472.109-1.el8 
  - pin attrs==24.3.0, pytz==2024.2, filelock==3.16.1 as they release newer versions.

* **Have tests been run against this PR?**  


* **Have appropriate comments and documentation been made on this PR?**  


* **Related changes in other repos** (link commit/PR here)


* **Other information**:



