### PR TITLE
Upgrade deps to support SigLIP2 models

### DIFF
--- a/requirements/amd64-gpu-requirements.txt
+++ b/requirements/amd64-gpu-requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=amd64-gpu-requirements.txt --strip-extras requirements.in
 #
---extra-index-url https://download.pytorch.org/whl/cu113
+--extra-index-url https://download.pytorch.org/whl/cu116
 
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.10.9
     # via
@@ -15,6 +15,8 @@ aiohttp==3.10.9
     #   fsspec
 aiosignal==1.3.2
     # via aiohttp
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via
     #   -r requirements.in
@@ -27,6 +29,7 @@ async-timeout==4.0.3
     #   redis
 attrs==24.3.0
     # via
+    #   -r requirements.in
     #   aiohttp
     #   jsonschema
 audioread==3.0.1
@@ -67,7 +70,7 @@ coloredlogs==15.0.1
     #   optimum
 datasets==2.19.1
     # via optimum
-decorator==5.1.1
+decorator==5.2.1
     # via
     #   librosa
     #   validators
@@ -79,18 +82,19 @@ dill==0.3.8
     #   multiprocess
 einops==0.6.1
     # via -r requirements.in
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via anyio
-fastapi==0.86.0
+fastapi==0.115.12
     # via
     #   -r requirements.in
     #   fastapi-utils
-fastapi-utils==0.2.1
+fastapi-utils==0.8.0
     # via -r requirements.in
 ffmpeg-python==0.2.0
     # via -r requirements.in
 filelock==3.16.1
     # via
+    #   -r requirements.in
     #   datasets
     #   huggingface-hub
     #   transformers
@@ -119,13 +123,13 @@ future==1.0.0
 fvcore==0.1.5.post20221221
     # via pytorchvideo
 greenlet==3.1.1
-    # via
-    #   -r requirements.in
-    #   sqlalchemy
+    # via -r requirements.in
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+hf-transfer==0.1.8
+    # via -r requirements.in
 httpcore==0.18.0
     # via httpx
 httptools==0.6.1
@@ -165,7 +169,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.4.2
+joblib==1.5.1
     # via
     #   librosa
     #   nltk
@@ -193,8 +197,13 @@ more-itertools==10.4.0
 mpmath==1.3.0
     # via sympy
 msgpack==1.1.0
-    # via librosa
-multidict==6.1.0
+    # via
+    #   -r requirements.in
+    #   librosa
+    #   msgpack-numpy
+msgpack-numpy==0.4.8
+    # via -r requirements.in
+multidict==6.4.4
     # via
     #   aiohttp
     #   yarl
@@ -221,6 +230,7 @@ numpy==1.23.4
     #   decord
     #   fvcore
     #   librosa
+    #   msgpack-numpy
     #   numba
     #   onnx
     #   onnxruntime
@@ -241,11 +251,13 @@ onnxruntime==1.13.1
     # via -r requirements.in
 onnxruntime-gpu==1.12.1 ; platform_machine == "x86_64"
     # via -r requirements.in
-open-clip-torch==2.24.0
+open-clip-torch==2.32.0
     # via -r requirements.in
 opencv-python-headless==4.6.0.66
     # via -r requirements.in
-optimum==1.20.0
+optimum==1.23.3
+    # via -r requirements.in
+orjson==3.10.15
     # via -r requirements.in
 packaging==24.1
     # via
@@ -271,39 +283,42 @@ pillow==10.4.0
     #   torchvision
 pkgutil-resolve-name==1.3.10
     # via -r requirements.in
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via pooch
 pooch==1.8.2
     # via librosa
 portalocker==2.10.1
-    # via iopath
+    # via
+    #   -r requirements.in
+    #   iopath
 protobuf==3.20.1
     # via
     #   -r requirements.in
     #   onnx
     #   onnxruntime
     #   onnxruntime-gpu
-    #   open-clip-torch
-    #   transformers
 psutil==5.9.4
     # via
     #   -r requirements.in
+    #   fastapi-utils
     #   memory-profiler
 pyarrow==17.0.0
     # via
     #   -r requirements.in
     #   datasets
-pyarrow-hotfix==0.6
+pyarrow-hotfix==0.7
     # via datasets
 pycparser==2.22
     # via cffi
 pycurl==7.45.3
     # via -r requirements.in
-pydantic==1.10.11
+pydantic==2.11.1
     # via
     #   -r requirements.in
     #   fastapi
     #   fastapi-utils
+pydantic-core==2.33.0
+    # via pydantic
 pynvml==11.5.0
     # via -r requirements.in
 pyrsistent==0.20.0
@@ -314,12 +329,16 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.0.1
     # via -r requirements.in
+python-json-logger==3.3.0
+    # via -r requirements.in
 python-magic==0.4.27
     # via -r requirements.in
 pytorchvideo==0.1.5
     # via -r requirements.in
 pytz==2024.2
-    # via pandas
+    # via
+    #   -r requirements.in
+    #   pandas
 pyyaml==6.0.2
     # via
     #   datasets
@@ -352,6 +371,7 @@ s3transfer==0.6.2
 safetensors==0.4.1
     # via
     #   -r requirements.in
+    #   open-clip-torch
     #   timm
     #   transformers
 scikit-learn==1.3.2
@@ -370,10 +390,7 @@ semver==3.0.2
 sentence-transformers==2.2.2
     # via -r requirements.in
 sentencepiece==0.2.0
-    # via
-    #   open-clip-torch
-    #   sentence-transformers
-    #   transformers
+    # via sentence-transformers
 six==1.14.0
     # via
     #   -r requirements.in
@@ -391,11 +408,9 @@ soxr==0.3.7
     # via
     #   -r requirements.in
     #   librosa
-sqlalchemy==1.4.54
-    # via fastapi-utils
-starlette==0.20.4
+starlette==0.46.2
     # via fastapi
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   onnxruntime
     #   onnxruntime-gpu
@@ -406,15 +421,17 @@ termcolor==2.4.0
     # via
     #   -r requirements.in
     #   fvcore
-threadpoolctl==3.5.0
+threadpoolctl==3.6.0
     # via scikit-learn
 timm==1.0.8
     # via
     #   -r requirements.in
     #   open-clip-torch
-tokenizers==0.19.1
-    # via transformers
-torch==1.12.1+cu113 ; platform_machine == "x86_64"
+tokenizers==0.20.2
+    # via
+    #   -r requirements.in
+    #   transformers
+torch==1.13.1+cu116 ; platform_machine == "x86_64"
     # via
     #   -r requirements.in
     #   clip-marqo
@@ -424,9 +441,9 @@ torch==1.12.1+cu113 ; platform_machine == "x86_64"
     #   timm
     #   torchaudio
     #   torchvision
-torchaudio==0.12.1+cu113 ; platform_machine == "x86_64"
+torchaudio==0.13.1+cu116 ; platform_machine == "x86_64"
     # via -r requirements.in
-torchvision==0.13.1+cu113 ; platform_machine == "x86_64"
+torchvision==0.14.1+cu116 ; platform_machine == "x86_64"
     # via
     #   -r requirements.in
     #   clip-marqo
@@ -445,32 +462,39 @@ tqdm==4.66.5
     #   open-clip-torch
     #   sentence-transformers
     #   transformers
-transformers==4.41.2
+transformers==4.45.2
     # via
     #   -r requirements.in
     #   multilingual-clip
     #   optimum
     #   sentence-transformers
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   -r requirements.in
+    #   exceptiongroup
+    #   fastapi
     #   huggingface-hub
     #   iopath
     #   librosa
     #   multidict
     #   onnx
     #   pydantic
+    #   pydantic-core
+    #   python-json-logger
     #   readerwriterlock
     #   starlette
     #   torch
     #   torchvision
+    #   typing-inspection
     #   uvicorn
+typing-inspection==0.4.1
+    # via pydantic
 urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore
     #   requests
-uvicorn==0.31.0
+uvicorn==0.34.0
     # via -r requirements.in
 uvloop==0.20.0
     # via -r requirements.in
@@ -495,9 +519,3 @@ zipp==3.20.2
     #   -r requirements.in
     #   importlib-metadata
     #   importlib-resources
-hf-transfer==0.1.8
-    # via
-    #   -r requirements.in
-orjson==3.10.15
-    # via
-    #   -r requirements.in

--- a/requirements/arm64-requirements.txt
+++ b/requirements/arm64-requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=arm64-requirements.txt --strip-extras requirements.in
 #
---extra-index-url https://download.pytorch.org/whl/cu113
+--extra-index-url https://download.pytorch.org/whl/cu116
 
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.10.9
     # via
@@ -15,6 +15,8 @@ aiohttp==3.10.9
     #   fsspec
 aiosignal==1.3.2
     # via aiohttp
+annotated-types==0.7.0
+    # via pydantic
 anyio==3.7.1
     # via
     #   -r requirements.in
@@ -27,6 +29,7 @@ async-timeout==4.0.3
     #   redis
 attrs==24.3.0
     # via
+    #   -r requirements.in
     #   aiohttp
     #   jsonschema
 audioread==3.0.1
@@ -66,7 +69,7 @@ coloredlogs==15.0.1
     #   optimum
 datasets==2.19.1
     # via optimum
-decorator==5.1.1
+decorator==5.2.1
     # via
     #   librosa
     #   validators
@@ -76,18 +79,19 @@ dill==0.3.8
     #   multiprocess
 einops==0.6.1
     # via -r requirements.in
-exceptiongroup==1.2.2
+exceptiongroup==1.3.0
     # via anyio
-fastapi==0.86.0
+fastapi==0.115.12
     # via
     #   -r requirements.in
     #   fastapi-utils
-fastapi-utils==0.2.1
+fastapi-utils==0.8.0
     # via -r requirements.in
 ffmpeg-python==0.2.0
     # via -r requirements.in
 filelock==3.16.1
     # via
+    #   -r requirements.in
     #   datasets
     #   huggingface-hub
     #   transformers
@@ -120,6 +124,8 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+hf-transfer==0.1.8
+    # via -r requirements.in
 httpcore==0.18.0
     # via httpx
 httptools==0.6.1
@@ -159,7 +165,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.4.2
+joblib==1.5.1
     # via
     #   librosa
     #   nltk
@@ -187,8 +193,13 @@ more-itertools==10.4.0
 mpmath==1.3.0
     # via sympy
 msgpack==1.1.0
-    # via librosa
-multidict==6.1.0
+    # via
+    #   -r requirements.in
+    #   librosa
+    #   msgpack-numpy
+msgpack-numpy==0.4.8
+    # via -r requirements.in
+multidict==6.4.4
     # via
     #   aiohttp
     #   yarl
@@ -214,6 +225,7 @@ numpy==1.23.4
     #   datasets
     #   fvcore
     #   librosa
+    #   msgpack-numpy
     #   numba
     #   onnx
     #   onnxruntime
@@ -231,11 +243,13 @@ onnx==1.12.0
     # via -r requirements.in
 onnxruntime==1.13.1
     # via -r requirements.in
-open-clip-torch==2.24.0
+open-clip-torch==2.32.0
     # via -r requirements.in
 opencv-python-headless==4.6.0.66
     # via -r requirements.in
-optimum==1.20.0
+optimum==1.23.3
+    # via -r requirements.in
+orjson==3.10.15
     # via -r requirements.in
 packaging==24.1
     # via
@@ -260,38 +274,41 @@ pillow==10.4.0
     #   torchvision
 pkgutil-resolve-name==1.3.10
     # via -r requirements.in
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via pooch
 pooch==1.8.2
     # via librosa
 portalocker==2.10.1
-    # via iopath
+    # via
+    #   -r requirements.in
+    #   iopath
 protobuf==3.20.1
     # via
     #   -r requirements.in
     #   onnx
     #   onnxruntime
-    #   open-clip-torch
-    #   transformers
 psutil==5.9.4
     # via
     #   -r requirements.in
+    #   fastapi-utils
     #   memory-profiler
 pyarrow==17.0.0
     # via
     #   -r requirements.in
     #   datasets
-pyarrow-hotfix==0.6
+pyarrow-hotfix==0.7
     # via datasets
 pycparser==2.22
     # via cffi
 pycurl==7.45.3
     # via -r requirements.in
-pydantic==1.10.11
+pydantic==2.11.1
     # via
     #   -r requirements.in
     #   fastapi
     #   fastapi-utils
+pydantic-core==2.33.0
+    # via pydantic
 pynvml==11.5.0
     # via -r requirements.in
 pyrsistent==0.20.0
@@ -302,12 +319,16 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.0.1
     # via -r requirements.in
+python-json-logger==3.3.0
+    # via -r requirements.in
 python-magic==0.4.27
     # via -r requirements.in
 pytorchvideo==0.1.5
     # via -r requirements.in
 pytz==2024.2
-    # via pandas
+    # via
+    #   -r requirements.in
+    #   pandas
 pyyaml==6.0.2
     # via
     #   datasets
@@ -340,6 +361,7 @@ s3transfer==0.6.2
 safetensors==0.4.1
     # via
     #   -r requirements.in
+    #   open-clip-torch
     #   timm
     #   transformers
 scikit-learn==1.3.2
@@ -358,10 +380,7 @@ semver==3.0.2
 sentence-transformers==2.2.2
     # via -r requirements.in
 sentencepiece==0.2.0
-    # via
-    #   open-clip-torch
-    #   sentence-transformers
-    #   transformers
+    # via sentence-transformers
 six==1.14.0
     # via
     #   -r requirements.in
@@ -379,11 +398,9 @@ soxr==0.3.7
     # via
     #   -r requirements.in
     #   librosa
-sqlalchemy==1.4.54
-    # via fastapi-utils
-starlette==0.20.4
+starlette==0.46.2
     # via fastapi
-sympy==1.13.3
+sympy==1.14.0
     # via
     #   onnxruntime
     #   optimum
@@ -393,15 +410,17 @@ termcolor==2.4.0
     # via
     #   -r requirements.in
     #   fvcore
-threadpoolctl==3.5.0
+threadpoolctl==3.6.0
     # via scikit-learn
 timm==1.0.8
     # via
     #   -r requirements.in
     #   open-clip-torch
-tokenizers==0.19.1
-    # via transformers
-torch==1.12.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
+tokenizers==0.20.2
+    # via
+    #   -r requirements.in
+    #   transformers
+torch==1.13.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
     # via
     #   -r requirements.in
     #   clip-marqo
@@ -411,9 +430,9 @@ torch==1.12.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
     #   timm
     #   torchaudio
     #   torchvision
-torchaudio==0.12.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
+torchaudio==0.13.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
     # via -r requirements.in
-torchvision==0.13.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
+torchvision==0.14.1 ; platform_machine == "arm64" or platform_machine == "aarch64"
     # via
     #   -r requirements.in
     #   clip-marqo
@@ -432,32 +451,39 @@ tqdm==4.66.5
     #   open-clip-torch
     #   sentence-transformers
     #   transformers
-transformers==4.41.2
+transformers==4.45.2
     # via
     #   -r requirements.in
     #   multilingual-clip
     #   optimum
     #   sentence-transformers
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   -r requirements.in
+    #   exceptiongroup
+    #   fastapi
     #   huggingface-hub
     #   iopath
     #   librosa
     #   multidict
     #   onnx
     #   pydantic
+    #   pydantic-core
+    #   python-json-logger
     #   readerwriterlock
     #   starlette
     #   torch
     #   torchvision
+    #   typing-inspection
     #   uvicorn
+typing-inspection==0.4.1
+    # via pydantic
 urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore
     #   requests
-uvicorn==0.31.0
+uvicorn==0.34.0
     # via -r requirements.in
 uvloop==0.20.0
     # via -r requirements.in
@@ -482,9 +508,3 @@ zipp==3.20.2
     #   -r requirements.in
     #   importlib-metadata
     #   importlib-resources
-hf-transfer==0.1.8
-    # via
-    #   -r requirements.in
-orjson==3.10.15
-    # via
-    #   -r requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,8 +1,8 @@
 requests==2.28.1
 anyio==3.7.1
-fastapi==0.86.0
-uvicorn==0.31.0
-fastapi-utils==0.2.1
+fastapi==0.115.12
+uvicorn==0.34.0
+fastapi-utils==0.8.0
 jsonschema==4.17.1
 redis==4.4.4
 more_itertools==10.4.0
@@ -13,13 +13,13 @@ Pillow==10.4.0
 numpy==1.23.4
 validators==0.20.0
 sentence-transformers==2.2.2
-open_clip_torch==2.24.0
+open_clip_torch==2.32.0
 clip-marqo==1.0.2
 protobuf==3.20.1
 onnx==1.12.0
 onnxruntime==1.13.1
 pandas==1.5.1
-optimum==1.20.0
+optimum==1.23.3
 opencv-python-headless==4.6.0.66
 psutil==5.9.4
 multilingual-clip==1.0.10
@@ -28,17 +28,17 @@ flatbuffers==23.5.9
 certifi==2023.7.22
 idna==2.8
 six==1.14.0
-typing-extensions==4.8.0
+typing-extensions==4.12.2
 urllib3==1.26.17
 timm==1.0.8
-transformers==4.41.2
+transformers==4.45.2
 einops==0.6.1
 soundfile==0.12.1
 python-magic==0.4.27
 ffmpeg-python==0.2.0
 librosa==0.10.2.post1
 pytorchvideo==0.1.5
-pydantic==1.10.11
+pydantic==2.11.1
 httpx==0.25.0
 semver==3.0.2
 scipy==1.10.1
@@ -52,12 +52,17 @@ huggingface-hub==0.25.0
 jinja2==3.1.4
 hf-transfer==0.1.8
 orjson==3.10.15
+msgpack==1.1.0
+msgpack_numpy==0.4.8
+python-json-logger==3.3.0
+
 
 # AMD Specific packages
---extra-index-url https://download.pytorch.org/whl/cu113
-torch==1.12.1+cu113; platform_machine == "x86_64"
-torchaudio==0.12.1+cu113; platform_machine == "x86_64"
-torchvision==0.13.1+cu113; platform_machine == "x86_64"
+# see https://pytorch.org/get-started/previous-versions/#linux-and-windows-32
+--extra-index-url https://download.pytorch.org/whl/cu116
+torch==1.13.1+cu116; platform_machine == "x86_64"
+torchaudio==0.13.1; platform_machine == "x86_64"
+torchvision==0.14.1+cu116; platform_machine == "x86_64"
 onnxruntime-gpu==1.12.1; platform_machine == "x86_64"
 decord==0.6.0; platform_machine == "x86_64"
 # https://github.com/georgia-tech-db/eva-decord is a fork of decord that only works on macos
@@ -65,9 +70,10 @@ decord==0.6.0; platform_machine == "x86_64"
 # pip3 --no-cache-dir install --upgrade eva-decord==0.6.1
 
 # ARM Specific packages
-torch==1.12.1; platform_machine == "arm64" or platform_machine == "aarch64"
-torchaudio==0.12.1; platform_machine == "arm64" or platform_machine == "aarch64"
-torchvision==0.13.1; platform_machine == "arm64" or platform_machine == "aarch64"
+# see https://pytorch.org/get-started/previous-versions/#osx-32
+torch==1.13.1; platform_machine == "arm64" or platform_machine == "aarch64"
+torchaudio==0.13.1; platform_machine == "arm64" or platform_machine == "aarch64"
+torchvision==0.14.1; platform_machine == "arm64" or platform_machine == "aarch64"
 
 # Transitive dependencies
 aiohttp==3.10.9
@@ -92,7 +98,7 @@ scikit-learn==1.3.2
 soxr==0.3.7
 termcolor==2.4.0
 tqdm==4.66.5
-transformers==4.41.2
+tokenizers==0.20.2
 uvloop==0.20.0
 watchfiles==0.24.0
 websockets==13.1


### PR DESCRIPTION

* **What is the current behavior?**  
  * torch==1.12.1, torch-audio==0.12.1, torch-video==0.13.1
  * cuda version is 11.3
  * transformers==4.41.2
  * tokenizers==0.19.1
  * open_clip_torch==2.24.0
  * optimum==1.20.0
  * the following deps are specified in marqo repo

```
msgpack==1.1.0
msgpack_numpy==0.4.8
python-json-logger==3.3.0
pydantic==2.11.1
fastapi==0.115.12
fastapi-utils==0.8.0
uvicorn==0.34.0
```

* **What is the new behavior?**
  * torch==1.13.1, torch-audio==0.13.1, torch-video==0.14.1
  * cuda version is 11.6
  * transformers==4.45.2
  * tokenizers==0.20.2
  * open_clip_torch==2.32.0
  * optimum==1.23.3

  * deps introduced up until marqo 2.19.3 are merged here


* **Have tests been run against this PR?**  
Yes

* **Have appropriate comments and documentation been made on this PR?**  
N/A

* **Related changes in other repos** (link commit/PR here)


* **Other information**:



